### PR TITLE
Csv2json improvements

### DIFF
--- a/csv2json.py
+++ b/csv2json.py
@@ -27,6 +27,9 @@ next(raw_schedule)
 # "location":"Chase Field"  row[4]
 
 for row in raw_schedule:
+    # CSV uses 2-digit years; we want 4 digits in the JSON.
+    date = ''.join([row[0][:6], '20', row[0][-2:]])
+    
     # Remove the space and make "pm" lowercase
     time = ''.join(c.lower() for c in row[1] if not c.isspace())
     
@@ -38,7 +41,7 @@ for row in raw_schedule:
     opponent = row[3]
     opponent = opponent.replace('at', '').replace('Giants', '').strip()
 
-    json_data = { "date": row[0],
+    json_data = { "date": date,
                   "opponent": opponent,
                   "time": time,
                   "location": row[4] }


### PR DESCRIPTION
A few improvements to make csv2json.py's output a bit more compatible without manual tweaks:
1. Suppress conversion of first CSV row (headers) to JSON file
2. Convert CSV's 2-digit years to 4-digit years
3. Remove leading zeroes from game times. 02:00pm becomes 2:00pm
4. Use local time from CSV instead of eastern time
